### PR TITLE
Add drafted issue files for feature roadmap

### DIFF
--- a/.github/ISSUES/01-add-persistent-database.md
+++ b/.github/ISSUES/01-add-persistent-database.md
@@ -1,0 +1,12 @@
+# Add persistent database (SQLite)
+
+**Summary:** Replace in-memory storage with a persistent database (start with SQLite).
+
+**Acceptance criteria:**
+- Add SQLAlchemy (or equivalent) models for `Activity` and `Student`.
+- Persist participants and activity metadata to a DB file.
+- Update `src/app.py` endpoints to use the DB.
+- Provide migration / simple setup instructions in `README`.
+
+**Labels:** enhancement, backend, database
+**Estimate:** medium

--- a/.github/ISSUES/02-add-authentication-and-roles.md
+++ b/.github/ISSUES/02-add-authentication-and-roles.md
@@ -1,0 +1,11 @@
+# Add authentication and roles (students + admins)
+
+**Summary:** Add user accounts, login, and role-based access (admin vs student).
+
+**Acceptance criteria:**
+- Implement simple auth (session or JWT) and registration for students.
+- Admin role can create/edit/delete activities.
+- Protect admin endpoints; sign-up/unregister remain available to students.
+
+**Labels:** enhancement, auth, backend
+**Estimate:** medium

--- a/.github/ISSUES/03-add-admin-dashboard.md
+++ b/.github/ISSUES/03-add-admin-dashboard.md
@@ -1,0 +1,11 @@
+# Add admin dashboard for activity management
+
+**Summary:** Provide a simple UI for admins to create/edit/delete activities and view signups.
+
+**Acceptance criteria:**
+- New `/admin` static pages or SPA for managing activities and participants.
+- Admin flows call protected API endpoints.
+- Basic validation for activity creation (name, schedule, max participants).
+
+**Labels:** enhancement, frontend, admin
+**Estimate:** medium

--- a/.github/ISSUES/04-enforce-capacity-and-waitlist.md
+++ b/.github/ISSUES/04-enforce-capacity-and-waitlist.md
@@ -1,0 +1,10 @@
+# Enforce capacity and add waitlist support
+
+**Summary:** Prevent signups past `max_participants`; add optional waitlist.
+
+**Acceptance criteria:**
+- API returns proper error when full; optionally add `waitlist` entry.
+- Admin can view and promote waitlisted students.
+
+**Labels:** enhancement, backend
+**Estimate:** small

--- a/.github/ISSUES/05-add-email-notifications-and-bulk-mailer.md
+++ b/.github/ISSUES/05-add-email-notifications-and-bulk-mailer.md
@@ -1,0 +1,11 @@
+# Add email notifications and bulk mailer
+
+**Summary:** Send signup confirmation emails and provide admin bulk-mail to participants.
+
+**Acceptance criteria:**
+- Integrate SMTP/email (config via env vars).
+- Send confirmation on signup and notifications for cancellations/changes.
+- Admin endpoint to send bulk email to activity participants.
+
+**Labels:** enhancement, notifications
+**Estimate:** medium

--- a/.github/ISSUES/06-add-certificate-generation-and-export.md
+++ b/.github/ISSUES/06-add-certificate-generation-and-export.md
@@ -1,0 +1,10 @@
+# Add certificate generation and export (PDF/CSV)
+
+**Summary:** Allow admins to generate certificates for participants and export participant lists.
+
+**Acceptance criteria:**
+- CSV export for an activity.
+- PDF certificate generation template per participant (basic).
+
+**Labels:** enhancement, export
+**Estimate:** medium

--- a/.github/ISSUES/07-add-calendar-integration.md
+++ b/.github/ISSUES/07-add-calendar-integration.md
@@ -1,0 +1,10 @@
+# Add calendar integration (iCal / Google Calendar export)
+
+**Summary:** Allow users to add activity schedules to calendars.
+
+**Acceptance criteria:**
+- Provide iCal (.ics) download for activities.
+- Document how to add to Google Calendar (link or instructions).
+
+**Labels:** enhancement, integrations
+**Estimate:** small

--- a/.github/ISSUES/08-improve-search-and-discovery.md
+++ b/.github/ISSUES/08-improve-search-and-discovery.md
@@ -1,0 +1,10 @@
+# Improve search & discovery (filters, pagination)
+
+**Summary:** Add filtering (by day, availability) and pagination for `/activities`.
+
+**Acceptance criteria:**
+- Support query params to filter and paginate results.
+- Client UI supports filtering and paged lists.
+
+**Labels:** enhancement, api, frontend
+**Estimate:** small

--- a/.github/ISSUES/09-add-mobile-friendly-ui.md
+++ b/.github/ISSUES/09-add-mobile-friendly-ui.md
@@ -1,0 +1,10 @@
+# Add mobile-friendly UI / responsive improvements
+
+**Summary:** Improve frontend responsiveness and consider a mobile-first layout.
+
+**Acceptance criteria:**
+- Static UI passes basic mobile layout checks.
+- Consider a roadmap for a mobile app or mini-program.
+
+**Labels:** enhancement, frontend
+**Estimate:** small

--- a/.github/ISSUES/10-add-third-party-auth-and-firebase-option.md
+++ b/.github/ISSUES/10-add-third-party-auth-and-firebase-option.md
@@ -1,0 +1,10 @@
+# Add third-party auth (OAuth) and Firebase option
+
+**Summary:** Add optional OAuth login and document Firebase integration for auth/data.
+
+**Acceptance criteria:**
+- Provide a stubbed OAuth flow or docs to enable social login.
+- Document Firebase alternative architecture.
+
+**Labels:** docs, auth, integrations
+**Estimate:** medium

--- a/.github/ISSUES/11-add-realtime-updates-websocket.md
+++ b/.github/ISSUES/11-add-realtime-updates-websocket.md
@@ -1,0 +1,10 @@
+# Add realtime updates (WebSocket) for participant lists
+
+**Summary:** Use WebSockets to push participant updates to connected clients.
+
+**Acceptance criteria:**
+- Implement a simple WS endpoint to broadcast signup/unregister events.
+- Update frontend to subscribe for live changes.
+
+**Labels:** enhancement, realtime
+**Estimate:** medium

--- a/.github/ISSUES/12-add-analytics-and-reporting.md
+++ b/.github/ISSUES/12-add-analytics-and-reporting.md
@@ -1,0 +1,10 @@
+# Add analytics & reporting
+
+**Summary:** Track participation metrics and add simple reports for admins.
+
+**Acceptance criteria:**
+- Record signups with timestamps.
+- Admin report endpoint showing participation counts and trends.
+
+**Labels:** enhancement, analytics
+**Estimate:** medium

--- a/.github/ISSUES/13-add-docker-and-deployment-docs.md
+++ b/.github/ISSUES/13-add-docker-and-deployment-docs.md
@@ -1,0 +1,10 @@
+# Add Docker and basic deployment docs
+
+**Summary:** Provide Dockerfile and docker-compose for local and production-like runs.
+
+**Acceptance criteria:**
+- Add `Dockerfile` + optional `docker-compose.yml`.
+- Update `README` with run and deploy steps.
+
+**Labels:** devops, docs
+**Estimate:** small

--- a/.github/ISSUES/14-improve-api-pagination-errors-docs.md
+++ b/.github/ISSUES/14-improve-api-pagination-errors-docs.md
@@ -1,0 +1,11 @@
+# Improve API (pagination, errors, docs)
+
+**Summary:** Harden the API: consistent error responses, pagination, OpenAPI docs improvements.
+
+**Acceptance criteria:**
+- Standardized error schema.
+- Add pagination to `/activities`.
+- Ensure OpenAPI docs include new endpoints and auth details.
+
+**Labels:** enhancement, api, docs
+**Estimate:** small


### PR DESCRIPTION
Adds 14 markdown files under `.github/ISSUES/` containing drafted issue descriptions for planned features (database, auth, admin UI, notifications, exports, calendar, analytics, docker, etc.).

These files are provided so maintainers can quickly create GitHub issues from the drafts or review the text before creating issues directly.